### PR TITLE
Add mutex interfaces and implement basic mutex for interior mutability.

### DIFF
--- a/src/bsp/raspberrypi/console.rs
+++ b/src/bsp/raspberrypi/console.rs
@@ -1,19 +1,69 @@
-use crate::console;
+
+use crate::{synchronization, console, synchronization::NullLock};
 use core::fmt;
+use synchronization::interface::Mutex;
+/// The mutex protected part.
+struct QEMUOutputInner {
+    chars_written: usize,
+}
 
-struct QEMUOutput;
+pub struct QEMUOutput {
+    inner: NullLock<QEMUOutputInner>,
+}
 
-impl fmt::Write for QEMUOutput {
+
+static QEMU_OUTPUT: QEMUOutput = QEMUOutput::new();
+
+
+impl QEMUOutputInner {
+    const fn new() -> QEMUOutputInner {
+        QEMUOutputInner { chars_written: 0 }
+    }
+
+    fn write_char(&mut self, c: char) {
+        unsafe {
+            core::ptr::write_volatile(0x3F20_1000 as *mut u8, c as u8);
+        }
+
+        self.chars_written += 1;
+    }
+}
+
+impl fmt::Write for QEMUOutputInner {
     fn write_str(&mut self, s: &str) -> fmt::Result {
         for c in s.chars() {
-            unsafe {
-                core::ptr::write_volatile(0x3F20_1000 as *mut u8, c as u8);
+            if c == '\n' {
+                self.write_char('\r')
             }
+
+            self.write_char(c);
         }
+
         Ok(())
     }
 }
 
-pub fn console() -> impl console::interface::Write {
-    QEMUOutput {}
+impl QEMUOutput {
+    pub const fn new() -> QEMUOutput {
+        QEMUOutput {
+            inner: NullLock::new(QEMUOutputInner::new()),
+        }
+    }
+}
+
+pub fn console() -> &'static impl console::interface::All {
+    &QEMU_OUTPUT
+}
+
+impl console::interface::Write for QEMUOutput {
+    fn write_fmt(&self, args: core::fmt::Arguments) -> fmt::Result {
+       
+        self.inner.lock(|inner| fmt::Write::write_fmt(inner, args))
+    }
+}
+
+impl console::interface::Statistics for QEMUOutput {
+    fn chars_written(&self) -> usize {
+        self.inner.lock(|inner| inner.chars_written)
+    }
 }

--- a/src/console.rs
+++ b/src/console.rs
@@ -1,3 +1,19 @@
 pub mod interface {
-    pub use core::fmt::Write;
+    pub use core::fmt::Result;
+    pub use core::fmt::Arguments;
+
+    pub trait Write {
+        fn write_fmt(&self, args: Arguments) -> Result;
+    }
+       
+          
+    pub trait Statistics {    
+        fn chars_written(&self) -> usize {
+                  0
+        }
+    }
+     
+   /// '+' is the union of two traits :o
+   pub trait All = Write + Statistics;
+        
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,6 +5,7 @@
 #![feature(format_args_nl)]
 #![feature(global_asm)]
 #![feature(panic_info_message)]
+#![feature(trait_alias)]
 #![no_main]
 #![no_std]
 
@@ -15,11 +16,13 @@ mod panic_wait;
 mod runtime_init;
 mod memory;
 mod console;
+mod synchronization;
 
 
 unsafe fn kernel_init() -> ! {
-
+    use console::interface::Statistics;
     println!("Hello from Rust!");
-
-	panic!("Stopping here.")
+    println!("[1] Chars written: {}", bsp::console::console().chars_written());
+    println!("[2] Stopping here.");
+    cpu::wait_forever()
 }

--- a/src/synchronization.rs
+++ b/src/synchronization.rs
@@ -1,0 +1,49 @@
+
+use core::cell::UnsafeCell;
+
+
+pub struct NullLock<T>
+where T: ?Sized,
+{
+    data: UnsafeCell<T>,
+}
+//constructor
+impl<T> NullLock<T> {
+    
+    pub const fn new(data: T) -> Self {
+        Self {
+            data: UnsafeCell::new(data),
+        }
+    }
+}
+unsafe impl<T> Send for NullLock<T> where T: ?Sized + Send {}
+unsafe impl<T> Sync for NullLock<T> where T: ?Sized + Sync {}
+
+
+
+
+
+pub mod interface {
+    //object implementing Mutex trait will be granted an exclusive access to data
+    pub trait Mutex {
+        
+        type Data;
+
+        fn lock<R>(&self, f: impl FnOnce(&mut Self::Data) -> R) -> R;
+    }
+}
+
+
+
+impl<T> interface::Mutex for NullLock<T> {
+    type Data = T;
+
+    fn lock<R>(&self, f: impl FnOnce(&mut Self::Data) -> R) -> R {
+
+        let data = unsafe { 
+            &mut *self.data.get() 
+        };
+
+        f(data)
+    }
+}


### PR DESCRIPTION
Add basic mutex, allowing to take advantage of interior mutability. Change output console so that it does not rely on one static object of QEMUOutput (which wraps QEMUOutputInner object implementing traits for chars writing and persisting statistics about number of chars written).
This version of the mutex will work properly only on single-treaded system.