### PR TITLE
Introduce timestamps

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,10 +1,3 @@
-## SPDX-License-Identifier: MIT OR Apache-2.0
-##
-## Copyright (c) 2018-2021 Andre Richter <andre.o.richter@gmail.com>
-
-
-
-# Default to the RPi3
 BSP ?= rpi3
 
 # Default to a serial device name that is common in Linux.
@@ -74,13 +67,13 @@ DOCKER_TOOLS = $(DOCKER_CMD) $(DOCKER_IMAGE)
 ifeq ($(UNAME_S),Linux)
     DOCKER_CMD_DEV = $(DOCKER_CMD_INTERACT) $(DOCKER_ARG_DEV)
 
-    DOCKER_MINITERM = $(DOCKER_CMD_DEV) $(DOCKER_ARG_DIR_UTILS) $(DOCKER_IMAGE)
+    DOCKER_CHAINBOOT = $(DOCKER_CMD_DEV) $(DOCKER_ARG_DIR_UTILS) $(DOCKER_IMAGE)
 endif
 
 EXEC_QEMU     = $(QEMU_BINARY) -M $(QEMU_MACHINE_TYPE)
-EXEC_MINITERM = ruby ../utils/miniterm.rb
+EXEC_MINIPUSH = ruby ../utils/minipush.rb
 
-.PHONY: all $(KERNEL_ELF) $(KERNEL_BIN) doc qemu miniterm clippy clean readelf objdump nm check
+.PHONY: all $(KERNEL_ELF) $(KERNEL_BIN) doc qemu chainboot clippy clean readelf objdump nm check
 
 all: $(KERNEL_BIN)
 
@@ -104,8 +97,8 @@ qemu: $(KERNEL_BIN)
 	@$(DOCKER_QEMU) $(EXEC_QEMU) $(QEMU_RELEASE_ARGS) -kernel $(KERNEL_BIN)
 endif
 
-miniterm:
-	@$(DOCKER_MINITERM) $(EXEC_MINITERM) $(DEV_SERIAL)
+chainboot: $(KERNEL_BIN)
+	@$(DOCKER_CHAINBOOT) $(EXEC_MINIPUSH) $(DEV_SERIAL) $(KERNEL_BIN)
 
 clippy:
 	@RUSTFLAGS="$(RUSTFLAGS_PEDANTIC)" $(CLIPPY_CMD)

--- a/src/_arch/aarch64/cpu.rs
+++ b/src/_arch/aarch64/cpu.rs
@@ -8,10 +8,3 @@ pub fn wait_forever() -> ! {
     }
 }
 
-#[cfg(feature = "bsp_rpi3")]
-#[inline(always)]
-pub fn spin_for_cycles(n: usize) {
-    for _ in 0..n {
-        asm::nop();
-    }
-}

--- a/src/_arch/aarch64/cpu/boot.s
+++ b/src/_arch/aarch64/cpu/boot.s
@@ -5,14 +5,9 @@
 
 .equ _core_id_mask, 0b11
 
-//--------------------------------------------------------------------------------------------------
-// Public Code
-//--------------------------------------------------------------------------------------------------
 .section .text._start
 
-//------------------------------------------------------------------------------
-// fn _start()
-//------------------------------------------------------------------------------
+
 _start:
 	// Only proceed on the boot core. Park it otherwise.
 	mrs	x1, MPIDR_EL1
@@ -21,16 +16,12 @@ _start:
 	cmp	x1, x2
 	b.ne	1f
 
-	// If execution reaches here, it is the boot core. Now, prepare the jump to Rust code.
-
-	// Set the stack pointer.
 	ADR_REL	x0, __boot_core_stack_end_exclusive
 	mov	sp, x0
 
 	// Jump to Rust code.
 	b	_start_rust
 
-	// Infinitely wait for events (aka "park the core").
 1:	wfe
 	b	1b
 

--- a/src/_arch/aarch64/time.rs
+++ b/src/_arch/aarch64/time.rs
@@ -1,0 +1,100 @@
+
+use crate::{time, println};
+use core::time::Duration;
+use cortex_a::{barrier, regs::*};
+
+const NS_PER_S: u64 = 1_000_000_000;
+
+/// ARMv8 Generic Timer.
+struct GenericTimer;
+
+
+
+static TIME_MANAGER: GenericTimer = GenericTimer;
+
+//--------------------------------------------------------------------------------------------------
+// Private Code
+//--------------------------------------------------------------------------------------------------
+
+impl GenericTimer {
+    #[inline(always)]
+    fn read_cntpct(&self) -> u64 {
+        // Prevent that the counter is read ahead of time due to out-of-order execution.
+        unsafe { barrier::isb(barrier::SY) };
+        CNTPCT_EL0.get()
+    }
+}
+
+//--------------------------------------------------------------------------------------------------
+// Public Code
+//--------------------------------------------------------------------------------------------------
+
+/// Return a reference to the time manager.
+pub fn time_manager() -> &'static impl time::interface::TimeManager {
+    &TIME_MANAGER
+}
+
+//------------------------------------------------------------------------------
+// OS Interface Code
+//------------------------------------------------------------------------------
+
+impl time::interface::TimeManager for GenericTimer {
+    fn resolution(&self) -> Duration {
+        Duration::from_nanos(NS_PER_S / (CNTFRQ_EL0.get() as u64))
+    }
+
+    fn uptime(&self) -> Duration {
+        let current_count: u64 = self.read_cntpct() * NS_PER_S;
+        let frq: u64 = CNTFRQ_EL0.get() as u64;
+
+        Duration::from_nanos(current_count / frq)
+    }
+
+    fn spin_for(&self, duration: Duration) {
+        // Instantly return on zero.
+        if duration.as_nanos() == 0 {
+            return;
+        }
+
+        // Calculate the register compare value.
+        let frq = CNTFRQ_EL0.get();
+        let x = match frq.checked_mul(duration.as_nanos() as u64) {
+            None => {
+                println!("Too long duration");
+                return;
+            }
+            Some(val) => val,
+        };
+        let tval = x / NS_PER_S;
+
+        // Check if it is within supported bounds.
+        let warn: Option<&str> = if tval == 0 {
+            Some("smaller")
+        // The upper 32 bits of CNTP_TVAL_EL0 are reserved.
+        } else if tval > u32::max_value().into() {
+            Some("bigger")
+        } else {
+            None
+        };
+
+        if let Some(w) = warn {
+            println!(
+                "Spin duration {} than architecturally supported, skipping",
+                w
+            );
+            return;
+        }
+
+        // Set the compare value register.
+        CNTP_TVAL_EL0.set(tval);
+
+        // Kick off the counting.                       // Disable timer interrupt.
+        CNTP_CTL_EL0.modify(CNTP_CTL_EL0::ENABLE::SET + CNTP_CTL_EL0::IMASK::SET);
+
+        // ISTATUS will be '1' when cval ticks have passed. Busy-check it.
+        while !CNTP_CTL_EL0.matches_all(CNTP_CTL_EL0::ISTATUS::SET) {}
+
+        // Disable counting again.
+        CNTP_CTL_EL0.modify(CNTP_CTL_EL0::ENABLE::CLEAR);
+    }
+}

--- a/src/bsp/raspberrypi/link.ld
+++ b/src/bsp/raspberrypi/link.ld
@@ -1,3 +1,4 @@
+/* The address at which the the kernel binary will be loaded by the Raspberry's firmware */
 __rpi_load_addr = 0x80000;
 
 ENTRY(__rpi_load_addr)

--- a/src/cpu.rs
+++ b/src/cpu.rs
@@ -5,5 +5,3 @@ mod arch_cpu;
 mod boot;
 
 pub use arch_cpu::{nop, wait_forever};
-#[cfg(feature = "bsp_rpi3")]
-pub use arch_cpu::spin_for_cycles;

--- a/src/main.rs
+++ b/src/main.rs
@@ -19,6 +19,7 @@ mod memory;
 mod console;
 mod synchronization;
 mod driver;
+mod time;
 
 unsafe fn kernel_init() -> ! {
     use driver::interface::DriverManager;
@@ -37,13 +38,23 @@ unsafe fn kernel_init() -> ! {
 
 /// The main function running after the early init.
 fn kernel_main() -> ! {
-    use bsp::console::console;
-    use console::interface::All;
+    use core::time::Duration;
     use driver::interface::DriverManager;
+    use time::interface::TimeManager;
 
-    println!("[0] Booting on: {}", bsp::board_name());
+    println!(
+        "{} version {}",
+        env!("CARGO_PKG_NAME"),
+        env!("CARGO_PKG_VERSION")
+    );
+    println!("Booting on: {}", bsp::board_name());
 
-    println!("[1] Drivers loaded:");
+    println!(
+        "Architectural timer resolution: {} ns",
+        time::time_manager().resolution().as_nanos()
+    );
+
+    println!("Drivers loaded:");
     for (i, driver) in bsp::driver::driver_manager()
         .all_device_drivers()
         .iter()
@@ -52,16 +63,11 @@ fn kernel_main() -> ! {
         println!("      {}. {}", i + 1, driver.compatible());
     }
 
-    println!(
-        "[2] Chars written: {}",
-        bsp::console::console().chars_written()
-    );
-    println!("[3] Echoing input now");
+    // Test a failing timer case.
+    time::time_manager().spin_for(Duration::from_nanos(1));
 
-    // Discard any spurious received characters before going into echo mode.
-    console().clear_rx();
     loop {
-        let c = bsp::console::console().read_char();
-        bsp::console::console().write_char(c);
+        debug!("Spinning for 1 second");
+        time::time_manager().spin_for(Duration::from_secs(1));
     }
 }

--- a/src/print.rs
+++ b/src/print.rs
@@ -1,4 +1,5 @@
 use crate::{bsp, console};
+
 use core::fmt;
 
 #[doc(hidden)]
@@ -21,4 +22,21 @@ macro_rules! println {
     ($($arg:tt)*) => ({
         $crate::print::_print(format_args_nl!($($arg)*));
     })
+}
+
+/// Debug
+#[macro_export]
+macro_rules! debug {
+    ($string:expr) => ({
+        #[allow(unused_imports)]
+        use crate::time::time_manager;
+        
+
+        $crate::print::_print(format_args_nl!(
+            concat!($string, "TIME: {:>3}s {:03} ms"),
+            time_manager().uptime().as_secs(),
+            time_manager().uptime().subsec_micros()/1000,
+        ));
+    });
+    
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,0 +1,20 @@
+#[cfg(target_arch = "aarch64")]
+#[path = "_arch/aarch64/time.rs"]
+mod arch_time;
+
+pub use arch_time::time_manager;
+
+
+pub mod interface {
+    use core::time::Duration;
+
+    pub trait TimeManager {
+
+        fn resolution(&self) -> Duration;
+
+        fn uptime(&self) -> Duration;
+
+
+        fn spin_for(&self, duration: Duration);
+    }
+}


### PR DESCRIPTION
Introduce timestamp mechanism with ability to fetch clock resolution and uptime. 
Change delays in drivers to wait the requested by uart standard time rather then the number of spins.